### PR TITLE
Implemented (most) of digest use case

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>1.16.1</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
             <version>4.12.0</version>

--- a/src/main/java/data_access/CohereDataAccessObject.java
+++ b/src/main/java/data_access/CohereDataAccessObject.java
@@ -3,6 +3,7 @@ package data_access;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import okhttp3.*;
+import use_case.digest.DigestCohereDataAccessInterface;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
@@ -12,7 +13,7 @@ import java.util.Properties;
 /**
  * The DAO for interacting with the Cohere API.
  */
-public class CohereDataAccessObject {
+public class CohereDataAccessObject implements DigestCohereDataAccessInterface {
     // Constants
     private static final String BASE_URL = "https://api.cohere.ai/v1/";
     private static final String API_KEY;

--- a/src/main/java/data_access/CohereDataAccessObject.java
+++ b/src/main/java/data_access/CohereDataAccessObject.java
@@ -1,0 +1,86 @@
+package data_access;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import okhttp3.*;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Properties;
+
+/**
+ * The DAO for interacting with the Cohere API.
+ */
+public class CohereDataAccessObject {
+    // Constants
+    private static final String BASE_URL = "https://api.cohere.ai/v1/";
+    private static final String API_KEY;
+    private static final OkHttpClient client = new OkHttpClient();
+
+    static {
+        API_KEY = loadApiKey();
+    }
+
+    private static String loadApiKey() {
+        Properties properties = new Properties();
+        try (BufferedReader reader = new BufferedReader(new FileReader(".env"))) {
+            properties.load(reader);
+            return properties.getProperty("COHERE_API_KEY");
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new RuntimeException("Failed to load API key from .env file");
+        }
+    }
+
+    /**
+     * Summarizes the given input text using Cohere's summarization API.
+     *
+     * @param inputText The text to summarize.
+     * @return The summarized text.
+     * @throws IOException If an I/O error occurs.
+     */
+    public String summarize(String inputText) throws IOException {
+        // Build the endpoint URL
+        String endpoint = BASE_URL + "summarize";
+
+        // Create JSON payload with additional parameters
+        JsonObject jsonBody = new JsonObject();
+        jsonBody.addProperty("text", inputText);
+        jsonBody.addProperty("length", "short"); // Specify single-sentence summary
+
+        // Optionally, you can set other parameters like 'temperature', 'model', etc.
+        // jsonBody.addProperty("temperature", 0.5);
+
+        // Build the request
+        RequestBody body = RequestBody.create(
+                jsonBody.toString(),
+                MediaType.parse("application/json")
+        );
+
+        Request request = new Request.Builder()
+                .url(endpoint)
+                .post(body)
+                .addHeader("Authorization", "Bearer " + API_KEY)
+                .addHeader("Content-Type", "application/json")
+                .build();
+
+        // Execute the request and get the response
+        try (Response response = client.newCall(request).execute()) {
+            if (response.isSuccessful() && response.body() != null) {
+                String jsonResponse = response.body().string();
+
+                // Parse the JSON response
+                Gson gson = new Gson();
+                JsonObject jsonObject = gson.fromJson(jsonResponse, JsonObject.class);
+                String summary = jsonObject.get("summary").getAsString();
+
+                return summary;
+            } else {
+                // Handle error
+                String errorBody = response.body() != null ? response.body().string() : "No response body";
+                throw new IOException("Error: HTTP response code " + response.code() + "\n" + errorBody);
+            }
+        }
+    }
+}

--- a/src/main/java/data_access/NewsDataAccessObject.java
+++ b/src/main/java/data_access/NewsDataAccessObject.java
@@ -84,8 +84,7 @@ public class NewsDataAccessObject implements DigestNewsDataAccessInterface {
                                 ? articleObject.get("url").getAsString() : "";
                         String date = articleObject.has("publishedAt") && !articleObject.get("publishedAt").isJsonNull()
                                 ? articleObject.get("publishedAt").getAsString() : "";
-                        String description = articleObject.has("description") && !articleObject.get("description").isJsonNull()
-                                ? articleObject.get("description").getAsString() : "";
+                        String description = "";
 
                         // Fetch the article content from the URL
                         String content = "";
@@ -119,7 +118,7 @@ public class NewsDataAccessObject implements DigestNewsDataAccessInterface {
                         // Category is not available in the JSON, so set to an empty string
                         String category = "";
 
-                        Article article = new CommonArticle(title, author, category, content, link, date);
+                        Article article = new CommonArticle(title, author, category, content, link, date, description);
                         articles.add(article);
                     }
                     return articles;

--- a/src/main/java/data_access/NewsDataAccessObject.java
+++ b/src/main/java/data_access/NewsDataAccessObject.java
@@ -6,6 +6,11 @@ import entity.CommonArticle;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.select.Elements;
+import use_case.digest.DigestNewsDataAccessInterface;
+
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
@@ -18,7 +23,7 @@ import java.util.Properties;
 /**
  * The DAO for news data using OkHttp.
  */
-public class NewsDataAccessObject {
+public class NewsDataAccessObject implements DigestNewsDataAccessInterface {
     // Constants
     private static final String BASE_URL = "https://newsapi.org/v2/";
     private static final String API_KEY;
@@ -75,14 +80,42 @@ public class NewsDataAccessObject {
                                 ? articleObject.get("title").getAsString() : "";
                         String author = articleObject.has("author") && !articleObject.get("author").isJsonNull()
                                 ? articleObject.get("author").getAsString() : "";
-                        String content = articleObject.has("content") && !articleObject.get("content").isJsonNull()
-                                ? articleObject.get("content").getAsString() : "";
                         String link = articleObject.has("url") && !articleObject.get("url").isJsonNull()
                                 ? articleObject.get("url").getAsString() : "";
                         String date = articleObject.has("publishedAt") && !articleObject.get("publishedAt").isJsonNull()
                                 ? articleObject.get("publishedAt").getAsString() : "";
                         String description = articleObject.has("description") && !articleObject.get("description").isJsonNull()
                                 ? articleObject.get("description").getAsString() : "";
+
+                        // Fetch the article content from the URL
+                        String content = "";
+                        try {
+                            // Fetch the HTML content of the article URL
+                            Request articleRequest = new Request.Builder()
+                                    .url(link)
+                                    .addHeader("User-Agent", "Mozilla/5.0")
+                                    .build();
+
+                            try (Response articleResponse = client.newCall(articleRequest).execute()) {
+                                if (articleResponse.isSuccessful() && articleResponse.body() != null) {
+                                    String htmlContent = articleResponse.body().string();
+
+                                    // Parse the HTML content using jsoup
+                                    Document doc = Jsoup.parse(htmlContent, link);
+
+                                    // Attempt to extract the main content
+                                    content = extractMainContent(doc);
+
+                                } else {
+                                    // Handle error
+                                    System.err.println("Failed to fetch article content for URL: " + link);
+                                }
+                            }
+                        } catch (Exception e) {
+                            System.err.println("Error fetching article content for URL: " + link);
+                            e.printStackTrace();
+                        }
+
                         // Category is not available in the JSON, so set to an empty string
                         String category = "";
 
@@ -100,5 +133,30 @@ public class NewsDataAccessObject {
         } catch (Exception e) {
             throw new IOException("Error fetching articles: " + e.getMessage(), e);
         }
+    }
+
+    private String extractMainContent(Document doc) {
+        // Remove script and style elements
+        doc.select("script, style, noscript").remove();
+
+        // Attempt to select common content containers
+        Elements articleElements = doc.select("article");
+        if (articleElements.isEmpty()) {
+            // Fallback to selecting main content area
+            articleElements = doc.select("main");
+        }
+        if (articleElements.isEmpty()) {
+            // Fallback to selecting content based on common CSS classes
+            articleElements = doc.select("[class*=content], [class*=article], [id*=content], [id*=article]");
+        }
+
+        String textContent = articleElements.text();
+
+        // If still empty, fallback to body text
+        if (textContent.isEmpty()) {
+            textContent = doc.body().text();
+        }
+
+        return textContent;
     }
 }

--- a/src/main/java/entity/Article.java
+++ b/src/main/java/entity/Article.java
@@ -45,4 +45,9 @@ public interface Article {
      * @return the description of the article.
      */
     String getDescription();
+
+    /**
+     * Sets the description of the article.
+     */
+    void setDescription(String description);
 }

--- a/src/main/java/entity/CommonArticle.java
+++ b/src/main/java/entity/CommonArticle.java
@@ -7,14 +7,16 @@ public class CommonArticle implements Article {
     private final String content;
     private final String link;
     private final String date;
+    private String description;
 
-    public CommonArticle(String title, String author, String category, String content, String link, String date) {
+    public CommonArticle(String title, String author, String category, String content, String link, String date, String description) {
         this.title = title;
         this.author = author;
         this.category = category;
         this.content = content;
         this.link = link;
         this.date = date;
+        this.description = description;
     }
 
 
@@ -37,5 +39,10 @@ public class CommonArticle implements Article {
     public String getDate() { return date; }
 
     @Override
-    public String getDescription() { return ""; }
+    public String getDescription() { return description; }
+
+    @Override
+    public void setDescription(String description) {
+        this.description = description;
+    }
 }

--- a/src/main/java/interface_adapter/digest/DigestController.java
+++ b/src/main/java/interface_adapter/digest/DigestController.java
@@ -2,18 +2,26 @@ package interface_adapter.digest;
 
 import use_case.digest.DigestInputBoundary;
 import use_case.digest.DigestInputData;
+import use_case.digest.DigestOutputBoundary;
+import use_case.digest.DigestOutputData;
 
 public class DigestController {
 
     private final DigestInputBoundary digestUseCaseInteractor;
+    private final DigestOutputBoundary digestPresenter;
 
-    public DigestController(DigestInputBoundary digestUseCaseInteractor) {
+    public DigestController(DigestInputBoundary digestUseCaseInteractor, DigestOutputBoundary digestPresenter) {
         this.digestUseCaseInteractor = digestUseCaseInteractor;
+        this.digestPresenter = digestPresenter;
     }
 
     public void execute(String keyword, String fromDate, String toDate, String language, String sortBy, int page, int pageSize) {
         final DigestInputData digestInputData = new DigestInputData(keyword, fromDate, toDate, language, sortBy, page, pageSize);
 
         digestUseCaseInteractor.execute(digestInputData);
+
+        if (digestPresenter.getErrorMessage() != null) {
+            throw new RuntimeException("Error: " + digestPresenter.getErrorMessage());
+        }
     }
 }

--- a/src/main/java/interface_adapter/digest/DigestController.java
+++ b/src/main/java/interface_adapter/digest/DigestController.java
@@ -1,0 +1,19 @@
+package interface_adapter.digest;
+
+import use_case.digest.DigestInputBoundary;
+import use_case.digest.DigestInputData;
+
+public class DigestController {
+
+    private final DigestInputBoundary digestUseCaseInteractor;
+
+    public DigestController(DigestInputBoundary digestUseCaseInteractor) {
+        this.digestUseCaseInteractor = digestUseCaseInteractor;
+    }
+
+    public void execute(String keyword, String fromDate, String toDate, String language, String sortBy, int page, int pageSize) {
+        final DigestInputData digestInputData = new DigestInputData(keyword, fromDate, toDate, language, sortBy, page, pageSize);
+
+        digestUseCaseInteractor.execute(digestInputData);
+    }
+}

--- a/src/main/java/interface_adapter/digest/DigestPresenter.java
+++ b/src/main/java/interface_adapter/digest/DigestPresenter.java
@@ -1,0 +1,17 @@
+package interface_adapter.digest;
+
+import use_case.digest.DigestOutputBoundary;
+import use_case.digest.DigestOutputData;
+
+public class DigestPresenter implements DigestOutputBoundary {
+
+    @Override
+    public void prepareFailView(String errorMessage) {
+
+    }
+
+    @Override
+    public void prepareSuccessView(DigestOutputData outputData) {
+
+    }
+}

--- a/src/main/java/interface_adapter/digest/DigestPresenter.java
+++ b/src/main/java/interface_adapter/digest/DigestPresenter.java
@@ -4,14 +4,28 @@ import use_case.digest.DigestOutputBoundary;
 import use_case.digest.DigestOutputData;
 
 public class DigestPresenter implements DigestOutputBoundary {
+    private DigestOutputData outputData;
+    private String errorMessage;
+
+    public DigestPresenter() {}
 
     @Override
-    public void prepareFailView(String errorMessage) {
-
+    public void handleError(String errorMessage) {
+        this.errorMessage = errorMessage;
     }
 
     @Override
-    public void prepareSuccessView(DigestOutputData outputData) {
+    public void processOutput(DigestOutputData outputData) {
+        this.outputData = outputData;
+    }
 
+    @Override
+    public DigestOutputData getOutputData() {
+        return this.outputData;
+    }
+
+    @Override
+    public String getErrorMessage() {
+        return this.errorMessage;
     }
 }

--- a/src/main/java/interface_adapter/digest/DigestViewModel.java
+++ b/src/main/java/interface_adapter/digest/DigestViewModel.java
@@ -1,0 +1,4 @@
+package interface_adapter.digest;
+
+public class DigestViewModel {
+}

--- a/src/main/java/interface_adapter/digest/DigestViewModel.java
+++ b/src/main/java/interface_adapter/digest/DigestViewModel.java
@@ -1,4 +1,0 @@
-package interface_adapter.digest;
-
-public class DigestViewModel {
-}

--- a/src/main/java/use_case/digest/DigestCohereDataAccessInterface.java
+++ b/src/main/java/use_case/digest/DigestCohereDataAccessInterface.java
@@ -1,0 +1,8 @@
+package use_case.digest;
+
+import java.io.IOException;
+
+public interface DigestCohereDataAccessInterface {
+
+    String summarize(String inputText) throws IOException;
+}

--- a/src/main/java/use_case/digest/DigestInputBoundary.java
+++ b/src/main/java/use_case/digest/DigestInputBoundary.java
@@ -1,0 +1,6 @@
+package use_case.digest;
+
+public interface DigestInputBoundary {
+
+    void execute(DigestInputData digestInputData);
+}

--- a/src/main/java/use_case/digest/DigestInputData.java
+++ b/src/main/java/use_case/digest/DigestInputData.java
@@ -1,0 +1,49 @@
+package use_case.digest;
+
+public class DigestInputData {
+
+    private final String keyword;
+    private final String fromDate;
+    private final String toDate;
+    private final String language;
+    private final String sortBy;
+    private final int page;
+    private final int pageSize;
+
+    public DigestInputData(String keyword, String fromDate, String toDate, String language, String sortBy, int page, int pageSize) {
+        this.keyword = keyword;
+        this.fromDate = fromDate;
+        this.toDate = toDate;
+        this.language = language;
+        this.sortBy = sortBy;
+        this.page = page;
+        this.pageSize = pageSize;
+    }
+
+    String getKeyword() {
+        return keyword;
+    }
+
+    String getFromDate() {
+        return fromDate;
+    }
+
+    String getToDate() {
+        return toDate;
+    }
+
+    String getLanguage() {
+        return language;
+    }
+
+    String getSortBy() {
+        return sortBy;
+    }
+
+    int getPage() {
+        return page;
+    }
+    int getPageSize() {
+        return pageSize;
+    }
+}

--- a/src/main/java/use_case/digest/DigestInteractor.java
+++ b/src/main/java/use_case/digest/DigestInteractor.java
@@ -1,0 +1,42 @@
+package use_case.digest;
+
+import entity.Article;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class DigestInteractor implements DigestInputBoundary{
+
+    private final DigestNewsDataAccessInterface digestNewsDataAccessInterface;
+    private final DigestOutputBoundary digestPresenter;
+
+    public DigestInteractor(DigestNewsDataAccessInterface digestNewsDataAccessInterface, DigestOutputBoundary digestPresenter) {
+        this.digestNewsDataAccessInterface = digestNewsDataAccessInterface;
+        this.digestPresenter = digestPresenter;
+    }
+
+    @Override
+    public void execute(DigestInputData digestInputData) {
+        final String keyword = digestInputData.getKeyword();
+        final String fromDate = digestInputData.getFromDate();
+        final String toDate =  digestInputData.getToDate();
+        final String language = digestInputData.getLanguage();
+        final String sortBy = digestInputData.getSortBy();
+        final int page = digestInputData.getPage();
+        final int pageSize = digestInputData.getPageSize();
+
+        List<Article> articles = new ArrayList<>();
+
+        try {
+            articles = digestNewsDataAccessInterface.fetchArticlesByKeyword(keyword, fromDate, toDate, language, sortBy, page, pageSize);
+        } catch (IOException e) {
+            digestPresenter.prepareFailView("Error in fetching articles");
+            e.printStackTrace();
+        }
+
+        final DigestOutputData digestOutputData = new DigestOutputData(articles);
+
+        digestPresenter.prepareSuccessView(digestOutputData);
+    }
+}

--- a/src/main/java/use_case/digest/DigestNewsDataAccessInterface.java
+++ b/src/main/java/use_case/digest/DigestNewsDataAccessInterface.java
@@ -1,0 +1,17 @@
+package use_case.digest;
+
+import entity.Article;
+
+import java.io.IOException;
+import java.util.List;
+
+public interface DigestNewsDataAccessInterface {
+
+    List<Article> fetchArticlesByKeyword(String keyword,
+                                         String fromDate,
+                                         String toDate,
+                                         String language,
+                                         String sortBy,
+                                         int page,
+                                         int pageSize) throws IOException;
+}

--- a/src/main/java/use_case/digest/DigestOutputBoundary.java
+++ b/src/main/java/use_case/digest/DigestOutputBoundary.java
@@ -1,0 +1,7 @@
+package use_case.digest;
+
+public interface DigestOutputBoundary {
+    void prepareFailView(String errorMessage);
+
+    void prepareSuccessView(DigestOutputData outputData);
+}

--- a/src/main/java/use_case/digest/DigestOutputBoundary.java
+++ b/src/main/java/use_case/digest/DigestOutputBoundary.java
@@ -1,7 +1,11 @@
 package use_case.digest;
 
 public interface DigestOutputBoundary {
-    void prepareFailView(String errorMessage);
+    void handleError(String errorMessage);
 
-    void prepareSuccessView(DigestOutputData outputData);
+    void processOutput(DigestOutputData outputData);
+
+    DigestOutputData getOutputData();
+
+    String getErrorMessage();
 }

--- a/src/main/java/use_case/digest/DigestOutputData.java
+++ b/src/main/java/use_case/digest/DigestOutputData.java
@@ -1,0 +1,18 @@
+package use_case.digest;
+
+import entity.Article;
+
+import java.util.List;
+
+public class DigestOutputData {
+
+    private final List<Article> articles;
+
+    public DigestOutputData(List<Article> articles) {
+        this.articles = articles;
+    }
+
+    public List<Article> getArticles() {
+        return articles;
+    }
+}

--- a/src/test/java/use_case/digest/DigestInteractorTest.java
+++ b/src/test/java/use_case/digest/DigestInteractorTest.java
@@ -1,0 +1,87 @@
+package use_case.digest;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import use_case.digest.DigestCohereDataAccessInterface;
+import use_case.digest.DigestNewsDataAccessInterface;
+import data_access.NewsDataAccessObject;
+import data_access.CohereDataAccessObject;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class DigestInteractorTest {
+
+    private DigestNewsDataAccessInterface newsDataAccess;
+    private DigestCohereDataAccessInterface cohereDataAccess;
+
+    @BeforeEach
+    public void setUp() {
+        // Use the actual NewsAPI and CohereAPI implementations
+        newsDataAccess = new NewsDataAccessObject();
+        cohereDataAccess = new CohereDataAccessObject();
+    }
+
+    @Test
+    public void testFetchArticlesSuccessfully() throws IOException {
+        // Arrange
+        String keyword = "technology";
+        String fromDate = java.time.LocalDate.now().toString(); // Current date
+        String language = "en";
+        String sortBy = "popularity";
+        int page = 1;
+        int pageSize = 5;
+
+        // Act
+        var articles = newsDataAccess.fetchArticlesByKeyword(keyword, fromDate, null, language, sortBy, page, pageSize);
+
+        // Assert
+        assertNotNull(articles, "Articles should not be null");
+        assertTrue(articles.size() > 0, "Articles list should not be empty");
+        assertEquals(5, articles.size(), "Articles list should contain 5 items");
+    }
+
+    @Test
+    public void testFetchArticlesFailure() {
+        // Arrange
+        String invalidKeyword = ""; // Invalid input to simulate failure
+        String fromDate = java.time.LocalDate.now().toString(); // Current date
+        String language = "en";
+        String sortBy = "popularity";
+        int page = 1;
+        int pageSize = 5;
+
+        // Act & Assert
+        assertThrows(IOException.class, () -> {
+            newsDataAccess.fetchArticlesByKeyword(invalidKeyword, fromDate, null, language, sortBy, page, pageSize);
+        }, "Should throw IOException for invalid input");
+    }
+
+    @Test
+    public void testSummarizeSuccessfully() throws IOException {
+        // Arrange
+        String content = "This is a sample text for summarization, " +
+                "note that this text must be longer than 250 characters. " +
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum eu fermentum eros. " +
+                "Vivamus ac nisi malesuada, varius metus et, tincidunt lacus. Fusce cursus congue nulla non pulvinar.";
+
+        // Act
+        String summary = cohereDataAccess.summarize(content);
+
+        // Assert
+        assertNotNull(summary, "Summary should not be null");
+        assertFalse(summary.isEmpty(), "Summary should not be empty");
+    }
+
+    @Test
+    public void testSummarizeFailure() {
+        // Arrange
+        String invalidContent = ""; // Invalid input to simulate failure
+
+        // Act & Assert
+        assertThrows(IOException.class, () -> {
+            cohereDataAccess.summarize(invalidContent);
+        }, "Should throw IOException for invalid input");
+    }
+}


### PR DESCRIPTION
Implemented (most) of the digest use case #3 . Here is a brief summary of additions:

- Added the Cohere integration that uses an article's content to generate a short summary
- Changed the Article entity to allow for description updates (where description is now the AI summary)
- Changed the content of the Article to now be web-scraped as the News API limits content to 200 chars
- Added the (for now) remaining files for the digest use_case
- Added simple tests for fetching articles and summarizing text

TODO:
- Look for bugs and review for code efficiency /  logic
- Review files to make sure they fully follow clean/solid principles, and that all parts are there
- Add more test cases